### PR TITLE
adds title to download button

### DIFF
--- a/src/Components/Views/Share.js
+++ b/src/Components/Views/Share.js
@@ -42,6 +42,7 @@ const Share = ({ data }) => {
       <button
         aria-label="linkedin"
         onClick={(evt) => download(data)}
+        title="Download the stats"
         style={{
           backgroundColor: "transparent",
           border: "none",


### PR DESCRIPTION
Adds a title to the button which download stats as PNG, because it misleads people to think that it is a 
'Scroll Down' button.