### PR TITLE
Updated README to list npm commands.

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,20 +13,27 @@
 
 
 ![Input](output/home.png)
-## Available Scripts
+# Available Scripts
 
 In the project directory, you can run:
 
-### `yarn start` // to serve the build files using express server
+## Before you begin
+`npm install`
 
-Runs the app in the development mode.<br />
-### `yarn dev` // to start the development server
+This installs all dependencies required by the project. <br />
 
+## For the developers:
+`npm run dev`
 
-### `yarn build` // to build
+This allows you to run this repo in the development environment, where you can make changes as well and see it get updated __live__. <br />
+ 
+## For the end users.
+```bash
+npm run build
+npm start
+```
 
-Builds the app for  to the `build` folder.<br />
-It correctly bundles React in production mode and optimizes the build for the best performance.
+The first command correctly bundles React in production mode and optimizes the build for the best performance. The second command allows you to serve this static file through a node server. <br/>
 
 # Sample Screen
 ![Input](output/dark.png)


### PR DESCRIPTION
Fixes #40 
I noticed that in the bash script __deploy.sh__, you have used npm only. The only place where yarn was mentioned was in the README.md. I've updated that.